### PR TITLE
fix: env name variable and api url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,11 @@
 PORT=3000
 
 # URL base de la API de BudgetBakers (ejemplo, ajustar según sea necesario)
-BUDGETBAKERS_API_URL=https://api.budgetbakers.com
+BUDGETBAKERS_API_URL=https://web-new.budgetbakers.com
 
 # URL de la instancia de CouchDB (ejemplo, ajustar según sea necesario)
 COUCHDB_URL=http://localhost:5984/budgetbakers_sync
 
 # Credenciales para BudgetBakers (si se usan directamente desde .env, aunque authService podría obtenerlas dinámicamente)
-# BUDGETBAKERS_USERNAME=tu_usuario
+# BUDGETBAKERS_EMAIL=tu_usuario
 # BUDGETBAKERS_PASSWORD=tu_contraseña


### PR DESCRIPTION
## Changes
- Fix '.env.example' variable name and default api url 

## Why
- The API doesn't work if you run cp `.env.example .env` as instructed in the README, because the variable names in the code don't match those in the example file

## PS 
Thanks for API!